### PR TITLE
Always use globally installed Ember CLI to create new Ember projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,20 @@ architecture utilizing [yarn workspaces](https://yarnpkg.com/features/workspaces
 
 ## Installation
 
+1. Ensure that `ember-cli` is installed globally.
+2. Install `ember-addon-tests` in your project.
+
 If using NPM:
 
 ```sh
+npm install --global ember-cli
 npm install --save-dev ember-addon-tests
 ```
 
+If using Yarn:
+
 ```sh
+yarn global add ember-cli
 yarn add --dev ember-addon-tests
 ```
 
@@ -75,6 +82,11 @@ expect(response.headers).to.include({
 // Stop Ember's development server again
 await testProject.stopEmberServer();
 ```
+
+`TestProject.createEmberApp()` and `TestProject.createEmberAddon()` methods
+use globally installed Ember CLI to create a new Ember project. They will use
+whatever Ember version is installed globally. Upgrade or downgrade globally
+installed Ember CLI to test your addon against different Ember CLI versions.
 
 ## API
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { kebabCase } from 'lodash';
 import initalizeWorkspace from './lib/initialize';
 import debug from './lib/debug';
 import { merge } from 'lodash';
+import os from 'os';
 
 const WORKSPACES: Map<string, string> = new Map();
 
@@ -223,7 +224,9 @@ export default class TestProject {
     ).version;
   }
 
-  private async modifyPackageJson(changes: {}): Promise<void> {
+  private async modifyPackageJson(
+    changes: Record<string, unknown>
+  ): Promise<void> {
     const packageJsonOfApp = JSON.parse(await this.readFile('package.json'));
 
     // apply changes to content of package.json
@@ -258,12 +261,16 @@ export default class TestProject {
       ],
       {
         // Ember CLI will either use the version of itself installed in the
-        // workspace if executed within workspace root. If ember-cli package
-        // is not installed yet in the workspace, it will fallback to the
-        // Ember CLI installed globally.
+        // workspace if executed within workspace root. This is even true
+        // if `ember-cli` package is not installed within the workspace root
+        // but only as a dependency of some other package in the workspace.
         // Some technical background could be found in this issue:
         // https://github.com/ember-cli/ember-cli/issues/9331
-        cwd: this.#workspaceRoot,
+        // This behavior makes it less easy to predict and control which
+        // Ember CLI version is used. This issue can be avoided by running
+        // `ember new` (or `ember addon`) command outside of the workspace
+        // root.
+        cwd: os.homedir(),
       }
     );
   }

--- a/tests/fixtures/ember-addon/package.json
+++ b/tests/fixtures/ember-addon/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "ember-addon",
+  "version": "1.0.0",
+  "main": "index.js",
+  "author": "Jeldrik Hanschke",
+  "license": "MIT",
+  "devDependencies": {
+    "ember-cli": "~3.20.0"
+  }
+}


### PR DESCRIPTION
If `ember-cli` package was installed by at least one package in the workspace Ember Addon Tests was using that version to create new Ember projects. Dependencies of a package under test are installed when creating a test project before consumer can execute any command. In practice a package under test defined the Ember CLI version used in the test suite if it depend on `ember-cli` package. This is not intuitive and made it difficult to execute the test suite against different Ember CLI versions.

This pull request forces Ember Addon Tests to always use global Ember CLI version. This also means that `ember-cli` package must be installed globally before.